### PR TITLE
Widen peerDependencies for react to v17

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,8 +90,8 @@
     "testEnvironment": "jest-environment-jsdom-sixteen"
   },
   "peerDependencies": {
-    "react": "^16.8",
-    "react-dom": "^16.8"
+    "react": "^16.8 || ^17.0.0",
+    "react-dom": "^16.8 || ^17.0.0"
   },
   "devDependencies": {
     "@babel/core": "7.12.9",


### PR DESCRIPTION
## What problem are we solving?

Installing via npm 7 in a project that has react@17 causes installation issues due to mis-matched peer dependencies.

## What does this do?

Widens the peerDependency requirements to include react@17.

## What does this not do?

## References and related issues:
